### PR TITLE
Set up protractor and add basic login specs

### DIFF
--- a/e2e/authentication.spec.js
+++ b/e2e/authentication.spec.js
@@ -1,0 +1,65 @@
+// Login/Logout Specs
+
+(function () {
+    'use strict';
+
+    describe('A user who is not logged in', function () {
+        var navigateToLoginScreen = function () {
+            var menuButton, loginButton;
+
+            menuButton = element.all(by.css('[menu-toggle="left"]'));
+            menuButton.get(1).click().then(function () {
+                // wait for open-menu transition to complete
+                browser.sleep(500);
+
+                loginButton = element(by.id('login-button')).isDisplayed();
+                loginButton.click().then(function () {
+                    // wait for the open-modal transition to complete
+                    browser.sleep(500);
+                });
+            });
+        };
+
+        beforeEach(function () {
+            browser.get('/');
+            navigateToLoginScreen();
+        });
+
+        it('should be able to navigate to the login screen', function () {
+            var loginForm = element(by.css('[ng-submit]')),
+                username = element(by.model('loginData.username')),
+                password = element(by.model('loginData.password'));
+
+            expect(loginForm.isPresent()).toBe(true);
+            expect(username.isPresent()).toBe(true);
+            expect(password.isPresent()).toBe(true);
+        });
+
+        it('should be able to log in with good credentials', function () {
+            var username = element(by.model('loginData.username')),
+                password = element(by.model('loginData.password')),
+                submitButton = element(by.css('[type="submit"]'));
+
+            username.sendKeys('lauren_ipsum');
+            password.sendKeys('password');
+            submitButton.click();
+            // wait for response + animation
+            browser.sleep(1500);
+
+            // no login elements
+            expect(element.all(by.model('longinData')).count()).toEqual(0);
+            // TODO: Replace with a real assertion
+        });
+
+        // TODO: login functionality is required before these tests make sense
+        // most common sad paths
+        xit('should not be able to submit form with an empty username', function () {});
+        xit('should not be able to submit form with an empty password', function () {});
+        xit('should not be able to log in with a bad password', function () {});
+        xit('should not be able to log in with an unknown username', function () {});
+    });
+
+    xdescribe('A logged in user', function () {
+        it('should be able to log out', function () {});
+    });
+}());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,10 +6,22 @@ var sass = require('gulp-sass');
 var minifyCss = require('gulp-minify-css');
 var rename = require('gulp-rename');
 var sh = require('shelljs');
+var protractor = require("gulp-protractor").protractor;
+var webdriverStandalone = require("gulp-protractor").webdriver_standalone;
 
 var paths = {
   sass: ['./scss/**/*.scss']
 };
+
+// run end-to-end tests
+gulp.task('protractor', function (done) {
+    gulp.src('./e2e/**/*.spec.js')
+        .pipe(protractor({
+            configFile: 'protractor.conf.js',
+        }))
+        .on('error', function (e) { throw e; })
+        .on('end', done);
+});
 
 gulp.task('default', ['sass']);
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "devDependencies": {
     "bower": "^1.3.3",
+    "gulp-protractor": "^1.0.0",
     "gulp-util": "^2.2.14",
+    "protractor": "^2.2.0",
     "shelljs": "^0.3.0"
   },
   "cordovaPlugins": [

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,0 +1,63 @@
+// Protractor configuration
+//
+// See the reference configuration for more options:
+// https://github.com/angular/protractor/blob/master/docs/referenceConf.js
+
+(function () {
+    'use strict';
+
+    exports.config = {
+        // The timeout for each script run on the browser. This should be longer
+        // than the maximum time your application needs to stabilize between tasks.
+        allScriptsTimeout: 110000,
+
+        // A base URL for your application under test. Calls to protractor.get()
+        // with relative paths will be prepended with this.
+        baseUrl: 'http://localhost:8100',
+
+        // Local path to standalone selenium server for gulp tasks. For more
+        // information, see:
+        // https://github.com/mllrsohn/gulp-protractor#protractor-webdriver
+        seleniumServerJar: './node_modules/protractor/selenium/selenium-server-standalone-2.45.0.jar',
+
+        // list of files / patterns to load in the browser
+        specs: [
+            'e2e/**/*.spec.js'
+        ],
+
+        // Patterns to exclude.
+        exclude: [],
+
+        // ----- Capabilities to be passed to the webdriver instance ----
+        //
+        // For a full list of available capabilities, see
+        // https://code.google.com/p/selenium/wiki/DesiredCapabilities
+        // and
+        // https://code.google.com/p/selenium/source/browse/javascript/webdriver/capabilities.js
+        capabilities: {
+            'browserName': 'chrome'
+        },
+
+        // ----- The test framework -----
+        //
+        // Jasmine and Cucumber are fully supported as a test and assertion framework.
+        // Mocha has limited beta support. You will need to include your own
+        // assertion framework if working with mocha.
+        framework: 'jasmine',
+        jasmineNodeOpts: {
+            showColors: true,
+            defaultTimeoutInterval: 30000,
+            isVerbose: true,
+        },
+
+        // ----- Setup and teardown -----
+        //
+        // Any actions to be taken before/after tests should be listed here.
+        onPrepare: function () {
+            // iPhone 6+ screen size
+            var width = 414, height = 628;
+            browser.driver.manage().window().setSize(width, height);
+            return;
+        },
+    };
+}());

--- a/www/templates/menu.html
+++ b/www/templates/menu.html
@@ -18,7 +18,7 @@
     </ion-header-bar>
     <ion-content>
       <ion-list>
-        <ion-item menu-close ng-click="login()">
+        <ion-item id="login-button" menu-close ng-click="login()">
           Login
         </ion-item>
         <ion-item menu-close href="#/app/search">


### PR DESCRIPTION
This change sets up protractor for e2e testing as well as creates the scaffold for authentication feature specs (towards #10). I'm submitting this as a PR before the full auth feature is complete because I figure that other features will need Protractor installed and set up as well.

## Changes:

- change: add id to menu login button for easier selection in tests
- add: `gulp protractor` task in gulpfile
- add: protractor/gulp dependencies
- add: scaffold for authentication feature tests (login/logout)

This change shouldn't have side effects on the working code as it's segregated into its own `e2e` folder and gulp task. It may cause merge conflicts for others working with the gulpfile or installing npm packages, but that should be easily resolved.